### PR TITLE
Add GreyNoise Integration for IOC Lookups

### DIFF
--- a/src/sites.ts
+++ b/src/sites.ts
@@ -36,8 +36,8 @@ export const greynoiseSearch: searchSite = {
     description: 'Provides context and reputation for IP addresses involved in internet scanning.',
     site: GREYNOISE_SEARCH,
     ip: true, 
-    hash: true, 
-    domain: true, 
+    hash: false, 
+    domain: false, 
     multisearch: false, 
     enabled: true 
 }

--- a/src/sites.ts
+++ b/src/sites.ts
@@ -8,6 +8,8 @@ export const CENSYS_SEARCH = 'https://search.censys.io/hosts/%s';
 export const DDG_SEARCH = 'https://duckduckgo.com/?q="%s"';
 export const BAZAAR_SEARCH_SHA256 = 'https://bazaar.abuse.ch/browse.php?search=sha256%3A%s';
 export const BAZAAR_SEARCH_MD5 = 'https://bazaar.abuse.ch/browse.php?search=md5%3A%s';
+export const GREYNOISE_SEARCH = 'https://viz.greynoise.io/ip/%s';
+
 
 export interface ParsedIndicators {
     title: string;
@@ -26,6 +28,18 @@ export interface searchSite {
     multisearch: boolean
     separator?: string
     enabled: boolean
+}
+
+export const greynoiseSearch: searchSite = {
+    name: 'GreyNoise',
+    shortName: 'GN',
+    description: 'Provides context and reputation for IP addresses involved in internet scanning.',
+    site: GREYNOISE_SEARCH,
+    ip: true, 
+    hash: true, 
+    domain: true, 
+    multisearch: false, 
+    enabled: true 
 }
 
 export const vtSearch: searchSite = {
@@ -125,4 +139,4 @@ export const spurSearch: searchSite = {
     enabled: false
 }
 
-export const defaultSites: searchSite[] = [vtSearch, ipdbSearch, googleSearch, ddgSearch, urlscanSearch, shodanSearch, censysSearch, spurSearch];
+export const defaultSites: searchSite[] = [vtSearch, ipdbSearch, googleSearch, ddgSearch, urlscanSearch, shodanSearch, censysSearch, spurSearch, greynoiseSearch];


### PR DESCRIPTION
This pull request introduces GreyNoise as a new IOC lookup site for the plugin. GreyNoise provides context and reputation for IP addresses involved in internet scanning activities, enhancing the plugin's capabilities for threat intelligence workflows.

### Changes Made
**New GreyNoise Search Integration:**

Added a constant `GREYNOISE_SEARCH` with the URL template: `https://viz.greynoise.io/ip/%s.`
Created a searchSite object (`greynoiseSearch`) with:
Support for IP lookups.
Disabled hash and domain support, as `GreyNoise` focuses on IPs.
Marked enabled by default.
Updated `defaultSites` Array:

Added greynoiseSearch to the list of default search sites.
Dynamic Inclusion:

GreyNoise is now dynamically included in the plugin's functionality wherever the `defaultSites` array is used.

**How It Works**
When processing an IP address (e.g., 8.8.8.8), the plugin now generates a link for `GreyNoise`:

`https://viz.greynoise.io/ip/192.168.1.1`

Clicking the link opens the GreyNoise website for reputation insights.

**Testing**

- Verified that GreyNoise links are correctly generated for IP addresses.
- Tested with multiple IOCs to ensure no disruption to existing functionality.
- Confirmed that GreyNoise integration works alongside other default search sites (e.g., VirusTotal, AbuseIPDB).



